### PR TITLE
update cron schedule to not execute every minute

### DIFF
--- a/templates/ecr-cron.yml
+++ b/templates/ecr-cron.yml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: aws-registry-credential-cron
 spec:
-  schedule: "* */8 * * *"
+  schedule: "0 */8 * * *"
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
   jobTemplate:


### PR DESCRIPTION
To prevent any issues with people using these files as-is, because the previous schedule would execute at every minute past every 8th hour.

<https://crontab.guru/#*_*/8_*_*_*>

VS

<https://crontab.guru/#0_*/8_*_*_*>