### PR TITLE
actually apply patch of serviceaccount

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -26,4 +26,4 @@ do
 done
 
 echo "Patching default serviceaccount"
-echo kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"aws-registry"}]}'
+kubectl patch serviceaccount default -p '{"imagePullSecrets":[{"name":"aws-registry"}]}'


### PR DESCRIPTION
**Edit:** While I thought this should be changed, having it changed and running it on my cluster gives me the following error:

```
Error from server (Forbidden): serviceaccounts "default" is forbidden: User "system:serviceaccount:infrastructure:ecr-update-service-account" cannot get resource "serviceaccounts" in API group "" in the namespace "infrastructure"
```

I figure this can be fixed by tweaking the Role/RoleBinding configuration, but I don't have any experience with that, so I couldn't figure out how to get that working.